### PR TITLE
Leverage Response::json() for building responses

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,9 +17,8 @@ if (!function_exists("jsend_error")) {
         ];
         if ($code) $response['code'] = $code;
         if ($data) $response['data'] = $data;
-        $response = json_encode($response);
-        $headers = array_merge(["Content-type" => "application/json"], $extraHeaders);
-        return response($response, $status, $headers);
+
+        return response()->json($response, $status, $extraHeaders);
     }
 }
 
@@ -32,12 +31,12 @@ if (!function_exists("jsend_fail")) {
      */
     function jsend_fail($data, $status = 400, $extraHeaders = [])
     {
-        $response = json_encode([
+        $response = [
             "status" => "fail",
             "data" => $data
-        ]);
-        $headers = array_merge(["Content-type" => "application/json"], $extraHeaders);
-        return response($response, $status, $headers);
+        ];
+
+        return response()->json($response, $status, $extraHeaders);
     }
 }
 
@@ -51,11 +50,11 @@ if (!function_exists("jsend_success")) {
     function jsend_success($data = [], $status = 200, $extraHeaders = [])
     {
         $data = ($data instanceof Illuminate\Database\Eloquent\Model) ? $data->toArray() : $data;
-        $response = json_encode([
+        $response = [
             "status" => "success",
             "data" => $data
-        ]);
-        $headers = array_merge(["Content-type" => "application/json"], $extraHeaders);
-        return response($response, $status, $headers);
+        ];
+
+        return response()->json($response, $status, $extraHeaders);
     }
 }


### PR DESCRIPTION
Instead of having to manually set `Content-Type: application/json` headers and running `json_encode()`, [Laravel includes a `Response::json()` method](https://laravel.com/docs/5.4/responses#json-responses) to handle these common tasks for you.

This PR refactors the three helpers to leverage `Response::json()` (by way of `response()->json()`).