### PR TITLE
Add trait which can be used to make Laravel exceptions and validation errors JSend-compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ public function create(Request $request)
 }
 ```
 
+(Optional) Use the `JsendExceptionFormatter` trait in `App\Exceptions\Handler` to send JSend-compliant responses for generic and validation errors if a request expects JSON:
+```php
+class Handler extends ExceptionHandler
+{
+    use Shalvah\LaravelJsend\JsendExceptionFormatter;
+    
+    // ...
+}
+```
+
 ## Available helpers
 ### `jsend_success`
 The `jsend_success` function creates a JSend **success** response instance.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
   "autoload": {
     "files": [
       "src/helpers.php"
-    ]
+    ],
+    "psr-4": {
+      "Shalvah\\LaravelJsend\\": "src/"
+    }
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/JsendExceptionFormatter.php
+++ b/src/JsendExceptionFormatter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Shalvah\LaravelJsend;
+
+use Exception;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @mixin \App\Exceptions\Handler
+ */
+trait JsendExceptionFormatter
+{
+    /**
+     * Convert a validation exception into a JSON response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Validation\ValidationException  $exception
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function invalidJson($request, ValidationException $exception)
+    {
+        return jsend_fail(
+            $exception->errors(),
+            $exception->status
+        );
+    }
+
+    /**
+     * Prepare a JSON response for the given exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Exception $e
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function prepareJsonResponse($request, Exception $e)
+    {
+        return jsend_error(
+            $e->getMessage(),
+            $e->getCode(),
+            null,
+            $this->isHttpException($e) ? $e->getStatusCode() : 500,
+            $this->isHttpException($e) ? $e->getHeaders() : []
+        );
+    }
+}

--- a/src/JsendExceptionFormatter.php
+++ b/src/JsendExceptionFormatter.php
@@ -16,7 +16,7 @@ trait JsendExceptionFormatter
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Validation\ValidationException  $exception
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
     protected function invalidJson($request, ValidationException $exception)
     {
@@ -31,7 +31,7 @@ trait JsendExceptionFormatter
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception $e
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
     protected function prepareJsonResponse($request, Exception $e)
     {

--- a/src/JsendExceptionFormatter.php
+++ b/src/JsendExceptionFormatter.php
@@ -3,6 +3,7 @@
 namespace Shalvah\LaravelJsend;
 
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -34,10 +35,24 @@ trait JsendExceptionFormatter
      */
     protected function prepareJsonResponse($request, Exception $e)
     {
+        $message = 'Server Error';
+        if (config('app.debug') || $this->isHttpException($e)) {
+            $message = $e->getMessage();
+        }
+
+        $data = config('app.debug') ? [
+            'exception' => get_class($e),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+            'trace' => collect($e->getTrace())->map(function ($trace) {
+                return Arr::except($trace, ['args']);
+            })->all(),
+        ] : null;
+
         return jsend_error(
-            $e->getMessage(),
+            $message,
             $e->getCode(),
-            null,
+            $data,
             $this->isHttpException($e) ? $e->getStatusCode() : 500,
             $this->isHttpException($e) ? $e->getHeaders() : []
         );


### PR DESCRIPTION
By default, when a request asks for a JSON response (i.e. in an API), general Laravel-generated errors and form validation errors are formatted like this:
```
{
    "message": "Something went wrong",
    "exception": "ErrorException",
    "file": "/var/www/html/...",
    "line": 123,
    "trace": [
          ...
    ]
}
```
```
{
    "message": "The given data was invalid.",
    "errors": {
        "fieldname": ["This field is required."]
    }
}
```

This PR add a trait that can be used in `App\Exceptions\Handler` that will convert these non-JSend-compliant responses like so:
```
{
    "status": "error",
    "message": "Something went wrong",
    "code": 123
}
```
```
{
    "status": "fail",
    "data": {
        "fieldname": ["This field is required."]
    }
}
```

This is not a breaking change because the trait is optional and needs to be explicitly used in `App\Exceptions\Handler` if this behavior is desired.