### PR TITLE
Move orchestra/testbench to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   ],
   "require": {
     "php": ">=7.2.5",
-    "laravel/framework": "^7.0|^8.0",
-    "orchestra/testbench": "^5.0|^6.0"
+    "laravel/framework": "^7.0|^8.0"
   },
   "require-dev": {
+    "orchestra/testbench": "^5.0|^6.0",
     "phpunit/phpunit": "^8.0"
   },
   "autoload": {


### PR DESCRIPTION
I don't believe there's any reason orchestra/testbench needs to be installed in production.